### PR TITLE
エラーメッセージの日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,4 @@ gem 'image_processing', '~> 1.2'
 gem 'active_hash'
 gem 'payjp'
 gem "aws-sdk-s3", require: false
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (7.0.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.4.7)
       actionpack (= 6.0.4.7)
       activesupport (= 6.0.4.7)
@@ -333,6 +336,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails
   rubocop
   sass-rails (~> 5)

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module Furima37588
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # 日本語の言語設定
+    config.i18n.default_locale = :ja
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,30 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        last_name: 名字
+        first_name: 名前
+        last_name_kana: 名字フリガナ
+        first_name_kana: 名前フリガナ
+        birth_date: 生年月日
+      item:
+        image: 画像
+        name: 商品名
+        description: 商品の説明
+        category_id: カテゴリー
+        condition_id: 商品の状態
+        shipping_fee_id: 配送料の負担
+        prefecture_id: 発送元の地域
+        shipping_schedule_id: 発送までの日数
+        price: 価格
+  
+  activemodel:
+    attributes:
+      order_sending_info:
+        token: クレジットカード情報
+        postal_code: 郵便番号
+        prefecture_id: 都道府県
+        city: 市区町村
+        address: 番地
+        phone_number: 電話番号

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -16,67 +16,67 @@ RSpec.describe Item, type: :model do
       it 'imageが空だと登録できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
+        expect(@item.errors.full_messages).to include("画像を入力してください")
       end
       it 'nameが空だと登録できない' do
         @item.name = ""
         @item.valid?
-        expect(@item.errors.full_messages).to include("Name can't be blank")
+        expect(@item.errors.full_messages).to include("商品名を入力してください")
       end
       it 'descriptionが空だと登録できない' do
         @item.description = ""
         @item.valid?
-        expect(@item.errors.full_messages).to include("Description can't be blank")
+        expect(@item.errors.full_messages).to include("商品の説明を入力してください")
       end
       it 'categoryが未選択（＝idが1）だと登録できない' do
         @item.category_id = "1"
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include("カテゴリーは1以外の値にしてください")
       end
       it 'conditionが未選択（＝idが1）だと登録できない' do
         @item.condition_id = "1"
         @item.valid?
-        expect(@item.errors.full_messages).to include("Condition must be other than 1")
+        expect(@item.errors.full_messages).to include("商品の状態は1以外の値にしてください")
       end
       it 'prefectureが未選択（＝idが1）だと登録できない' do
         @item.prefecture_id = "1"
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture must be other than 1")
+        expect(@item.errors.full_messages).to include("発送元の地域は1以外の値にしてください")
       end
       it 'shipping_feeが未選択（＝idが1）だと登録できない' do
         @item.shipping_fee_id = "1"
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping fee must be other than 1")
+        expect(@item.errors.full_messages).to include("配送料の負担は1以外の値にしてください")
       end
       it 'shipping_scheduleが未選択（＝idが1）だと登録できない' do
         @item.shipping_schedule_id = "1"
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping schedule must be other than 1")
+        expect(@item.errors.full_messages).to include("発送までの日数は1以外の値にしてください")
+      end
+      it 'priceが空だと登録できない' do
+        @item.price = ""
+        @item.valid?
+        expect(@item.errors.full_messages).to include("価格を入力してください")
       end
       it 'priceが300円未満だと登録できない' do
         @item.price = "1"
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
+        expect(@item.errors.full_messages).to include("価格は300以上の値にしてください")
       end
       it 'priceが9,999,999円を超えると登録できない' do
         @item.price = "99999999"
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999")
-      end
-      it 'priceが半角英語だと登録できない' do
-        @item.price = "test"
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include("価格は9999999以下の値にしてください")
       end
       it 'priceが全角文字だと登録できない' do
         @item.price = "１２３４５"
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include("価格は数値で入力してください")
       end
       it 'userが紐付いていなければ登録できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
+        expect(@item.errors.full_messages).to include("Userを入力してください")
       end
     end
   end

--- a/spec/models/order_sending_info_spec.rb
+++ b/spec/models/order_sending_info_spec.rb
@@ -23,72 +23,72 @@ RSpec.describe OrderSendingInfo, type: :model do
       it 'tokenが空だと購入できない' do
         @order_sending.token = nil
         @order_sending.valid?
-        expect(@order_sending.errors.full_messages).to include("Token can't be blank")
+        expect(@order_sending.errors.full_messages).to include("クレジットカード情報を入力してください")
       end
       it 'postal_codeが空だと購入できない' do
         @order_sending.postal_code = nil
         @order_sending.valid?
-        expect(@order_sending.errors.full_messages).to include("Postal code can't be blank")
+        expect(@order_sending.errors.full_messages).to include("郵便番号を入力してください")
       end
       it 'postal_codeが半角のハイフンを含んだ正しい形式でないと購入できない' do
         @order_sending.postal_code = "1234567"
         @order_sending.valid?
-        expect(@order_sending.errors.full_messages).to include("Postal code is invalid")
+        expect(@order_sending.errors.full_messages).to include("郵便番号は不正な値です")
       end
       it 'postal_codeが全角文字だと購入できない' do
         @order_sending.postal_code = "１２３−４５６７"
         @order_sending.valid?
-        expect(@order_sending.errors.full_messages).to include("Postal code is invalid")
+        expect(@order_sending.errors.full_messages).to include("郵便番号は不正な値です")
       end
       it 'prefectureが未選択（＝idが1）だと購入できない' do
         @order_sending.prefecture_id = "1"
         @order_sending.valid?
-        expect(@order_sending.errors.full_messages).to include("Prefecture must be other than 1")
+        expect(@order_sending.errors.full_messages).to include("都道府県は1以外の値にしてください")
       end
       it 'cityが空だと購入できない' do
         @order_sending.city = ""
         @order_sending.valid?
-        expect(@order_sending.errors.full_messages).to include("City can't be blank")
+        expect(@order_sending.errors.full_messages).to include("市区町村を入力してください")
       end
       it 'addressが空だと購入できない' do
         @order_sending.address = ""
         @order_sending.valid?
-        expect(@order_sending.errors.full_messages).to include("Address can't be blank")
+        expect(@order_sending.errors.full_messages).to include("番地を入力してください")
       end
       it 'phone_numberが空だと購入できない' do
         @order_sending.phone_number = ""
         @order_sending.valid?
-        expect(@order_sending.errors.full_messages).to include("Phone number can't be blank")
+        expect(@order_sending.errors.full_messages).to include("電話番号を入力してください")
       end
       it 'phone_numberがハイフンを含んだ形式であると購入できない' do
         @order_sending.phone_number = "090-1234-5678"
         @order_sending.valid?
-        expect(@order_sending.errors.full_messages).to include("Phone number is invalid")
+        expect(@order_sending.errors.full_messages).to include("電話番号は不正な値です")
       end
       it 'phone_numberが全角文字だと購入できない' do
         @order_sending.phone_number = "０９０１２３４５６７８"
         @order_sending.valid?
-        expect(@order_sending.errors.full_messages).to include("Phone number is invalid")
+        expect(@order_sending.errors.full_messages).to include("電話番号は不正な値です")
       end
       it 'phone_numberが9桁以下だと購入できない' do
         @order_sending.phone_number = "090"
         @order_sending.valid?
-        expect(@order_sending.errors.full_messages).to include("Phone number is invalid")
+        expect(@order_sending.errors.full_messages).to include("電話番号は不正な値です")
       end
       it 'phone_numberが12桁以上だと購入できない' do
         @order_sending.phone_number = "090123456789"
         @order_sending.valid?
-        expect(@order_sending.errors.full_messages).to include("Phone number is invalid")
+        expect(@order_sending.errors.full_messages).to include("電話番号は不正な値です")
       end
       it 'userが紐付いていないと購入できない' do
         @order_sending.user_id = nil
         @order_sending.valid?
-        expect(@order_sending.errors.full_messages).to include("User can't be blank")
+        expect(@order_sending.errors.full_messages).to include("Userを入力してください")
       end
       it 'itemが紐付いていないと購入できない' do
         @order_sending.item_id = nil
         @order_sending.valid?
-        expect(@order_sending.errors.full_messages).to include("Item can't be blank")
+        expect(@order_sending.errors.full_messages).to include("Itemを入力してください")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,112 +16,112 @@ RSpec.describe User, type: :model do
       it "nicknameが空だと登録できない" do
         @user.nickname = ""
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+        expect(@user.errors.full_messages).to include("ニックネームを入力してください")
       end
       it "emailが空では登録できない" do
         @user.email = ""
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        expect(@user.errors.full_messages).to include("Eメールを入力してください")
       end
       it 'passwordが空では登録できない' do
         @user.password = ""
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors.full_messages).to include("パスワードを入力してください")
       end
       it 'last_nameが空では登録できない' do
         @user.last_name = ""
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name can't be blank")
+        expect(@user.errors.full_messages).to include("名字を入力してください")
       end
       it 'first_nameが空では登録できない' do
         @user.first_name = ""
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name can't be blank")
+        expect(@user.errors.full_messages).to include("名前を入力してください")
       end
       it 'last_name_kanaが空では登録できない' do
         @user.last_name_kana = ""
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana can't be blank")
+        expect(@user.errors.full_messages).to include("名字フリガナを入力してください")
       end
       it 'first_name_kanaが空では登録できない' do
         @user.first_name_kana = ""
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana can't be blank")
+        expect(@user.errors.full_messages).to include("名前フリガナを入力してください")
       end
       it 'birth_dateが空では登録できない' do
         @user.birth_date = ""
         @user.valid?
-        expect(@user.errors.full_messages).to include("Birth date can't be blank")
+        expect(@user.errors.full_messages).to include("生年月日を入力してください")
       end
       it '重複したemailが存在する場合は登録できない' do
         @user.save
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include("Email has already been taken")
+        expect(another_user.errors.full_messages).to include("Eメールはすでに存在します")
       end
       it 'emailは@を含まないと登録できない' do
         @user.email = "testuser"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email is invalid")
+        expect(@user.errors.full_messages).to include("Eメールは不正な値です")
       end
       it 'passwordが5文字以下では登録できない' do
         @user.password = "ab123"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is too short (minimum is 6 characters)")
+        expect(@user.errors.full_messages).to include("パスワードは6文字以上で入力してください")
       end
       it '半角英字のみのpasswordでは登録できない' do
         @user.password = "123456789"
         @user.password_confirmation = "123456789"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is invalid")
+        expect(@user.errors.full_messages).to include("パスワードは不正な値です")
       end
       it '半角数字のみのpasswordでは登録できない' do
         @user.password = "abcdefg"
         @user.password_confirmation = "abcdefg"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is invalid")
+        expect(@user.errors.full_messages).to include("パスワードは不正な値です")
       end
       it '全角文字を含むpasswordでは登録できない' do
         @user.password = "abc１２３"
         @user.password_confirmation = "abc１２３"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is invalid")
+        expect(@user.errors.full_messages).to include("パスワードは不正な値です")
       end
       it 'passwordとpassword_confirmationが不一致では登録できない' do
         @user.password_confirmation = ""
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
       end
       it 'last_nameが半角では登録できない' do
         @user.last_name = "test"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name is invalid")
+        expect(@user.errors.full_messages).to include("名字は不正な値です")
       end
       it 'first_nameが半角では登録できない' do
         @user.first_name = "test"
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name is invalid")
+        expect(@user.errors.full_messages).to include("名前は不正な値です")
       end
       it 'last_name_kanaが半角では登録できない' do
         @user.last_name_kana = "test"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana is invalid")
+        expect(@user.errors.full_messages).to include("名字フリガナは不正な値です")
       end
       it 'last_name_kanaが全角（漢字・ひらがな）では登録できない' do
         @user.last_name_kana = "てすと"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana is invalid")
+        expect(@user.errors.full_messages).to include("名字フリガナは不正な値です")
       end
       it 'first_name_kanaが半角では登録できない' do
         @user.first_name_kana = "test"
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana is invalid")
+        expect(@user.errors.full_messages).to include("名前フリガナは不正な値です")
       end
       it 'first_name_kanaが全角（漢字・ひらがな）では登録できない' do
         @user.first_name_kana = "てすと"
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana is invalid")
+        expect(@user.errors.full_messages).to include("名前フリガナは不正な値です")
       end
     end
   end


### PR DESCRIPTION
# What
エラーメッセージの日本語化

# Why
英語表記を日本語に変更し、ユーザーの利便性を改善する